### PR TITLE
Content-Type guessing

### DIFF
--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -31,6 +31,7 @@ from ssl import SSLError
 import sys
 import tarfile
 import time
+import mimetypes
 
 from boto.s3.connection import S3Connection
 
@@ -199,7 +200,11 @@ def putter(put, put_queue, stat_queue, options):
             if key:
                 headers = {}
                 if options.content_type:
-                    headers['Content-Type'] = options.content_type
+                    if options.content_type == "guess":
+                        headers['Content-Type'] = mimetypes.guess_type(value.path)[0]
+                    else:
+                        headers['Content-Type'] = options.content_type
+
                 content = value.get_content()
                 if options.gzip:
                     headers['Content-Encoding'] = 'gzip'


### PR DESCRIPTION
Maybe you are interested in this small fixed I've made.

I had to upload a cuatrillion of files to S3 and I didn't want to add the content-type param divided in filetypes to upload, so I've made a small fix that uses the mimetype submodule to guess the content-type of the files to upload if you use the special --content-type=guess param.

Simple but it was überly awesome for me, hehe

Cheers!
