### PR TITLE
Fix single file upload.

### DIFF
--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -115,7 +115,7 @@ def walk_filesystem(source, options):
                 yield (key_name, dict(path=path))
     elif os.path.isfile(source):
         key_name = os.path.normpath(os.path.join(options.prefix, source))
-        yield (key_name, dict(path=path))
+        yield (key_name, dict(path=source))
 
 
 def walk_tar(source, options):


### PR DESCRIPTION
This fixes single file uploads. Used to reference 'path' but it is only defined if source is a directory. Not that useful in production but indispensable during development.
