### PR TITLE
Fix md5 for gzip'ed content

### DIFF
--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -213,6 +213,7 @@ def putter(put, put_queue, stat_queue, options):
                         headers['Content-Type'] = options.content_type
 
                 content = value.get_content()
+                md5 = value.md5
                 if options.gzip:
                     headers['Content-Encoding'] = 'gzip'
                     string_io = StringIO()
@@ -220,8 +221,9 @@ def putter(put, put_queue, stat_queue, options):
                     gzip_file.write(content)
                     gzip_file.close()
                     content = string_io.getvalue()
+                    md5 = compute_md5(StringIO(content))
                 if not options.dry_run:
-                    key.set_contents_from_string(content, headers, md5=value.md5, policy=options.grant)
+                    key.set_contents_from_string(content, headers, md5=md5, policy=options.grant)
                 logger.info('%s -> %s' % (value.path, key.name))
                 stat_queue.put(dict(size=value.get_size()))
             else:


### PR DESCRIPTION
MD5 is passed as value.md5, but this isn't valid for gzip'ed files and triggers the following error message.

```
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>BadDigest</Code><Message>The Content-MD5 you specified did not match what we received.</Message><ExpectedDigest>cBv2KZVF7F5fVeUbkkQGew==</ExpectedDigest><CalculatedDigest>o4oyfv3UJ+UmfOJ3kCa39w==</CalculatedDigest><RequestId>D458DEA2087B110E</RequestId><HostId>snip</HostId></Error>
```

The MD5 must be updated when using the gzip option rather than using the non-gzip'ed checksum.
