### PR TITLE
Add include and exclude options

### DIFF
--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -154,9 +154,10 @@ def walk_filesystem(source, options):
                 key_name = '/'.join([options.prefix] + rel_path.split(os.sep))
                 yield (key_name, dict(path=abs_path))
     elif os.path.isfile(source):
-        if not excluded(source, options):
-            key_name = os.path.normpath(os.path.join(options.prefix, source))
-            yield (key_name, dict(path=source))
+        if excluded(source, options):
+            continue
+        key_name = os.path.normpath(os.path.join(options.prefix, source))
+        yield (key_name, dict(path=source))
 
 
 def walk_tar(source, options):
@@ -165,12 +166,13 @@ def walk_tar(source, options):
         for tarinfo in tar_file:
             if tarinfo.isfile():
                 path = tarinfo.name
-                if not excluded(path, options):
-                    key_name = os.path.normpath(os.path.join(options.prefix, path))
-                    filename = source
-                    offset = tarinfo.offset_data
-                    size = tarinfo.size
-                    yield (key_name, dict(filename=filename, offset=offset, path=path, size=size))
+                if excluded(path, options):
+                    continue
+                key_name = os.path.normpath(os.path.join(options.prefix, path))
+                filename = source
+                offset = tarinfo.offset_data
+                size = tarinfo.size
+                yield (key_name, dict(filename=filename, offset=offset, path=path, size=size))
             # http://blogs.oucs.ox.ac.uk/inapickle/2011/06/20/high-memory-usage-when-using-pythons-tarfile-module/
             tar_file.members = []
     except tarfile.ReadError:
@@ -178,23 +180,25 @@ def walk_tar(source, options):
         for tarinfo in tar_file:
             if tarinfo.isfile():
                 path = tarinfo.name
-                if not excluded(path, options):
-                    key_name = os.path.normpath(os.path.join(options.prefix, path))
-                    content = tar_file.extractfile(tarinfo).read()
-                    yield (key_name, dict(content=content, path=path))
+                if excluded(path, options):
+                    continue
+                key_name = os.path.normpath(os.path.join(options.prefix, path))
+                content = tar_file.extractfile(tarinfo).read()
+                yield (key_name, dict(content=content, path=path))
 
 
 def walk_s3(source, options):
     connection = S3Connection(host=options.host, is_secure=options.secure)
     for key in connection.get_bucket(source).list():
-        if not excluded(key.name, options):
-            yield (
-                key.name,
-                dict(
-                    bucket_name=key.bucket.name,
-                    md5=key.etag,
-                    size=key.size,
-                    path='%s/%s' % (source, key.name)))
+        if excluded(key.name, options):
+            continue
+        yield (
+            key.name,
+            dict(
+                bucket_name=key.bucket.name,
+                md5=key.etag,
+                size=key.size,
+                path='%s/%s' % (source, key.name)))
 
 
 def walker(walk, put_queue, sources, options):

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -27,6 +27,7 @@ try:
     from cStringIO import StringIO
 except ImportError:
     from StringIO import StringIO
+import fnmatch
 from gzip import GzipFile
 from itertools import chain, imap, islice
 import logging
@@ -127,20 +128,35 @@ class Value(object):
     def should_copy_content(self):
         return self.bucket_name is None
 
+def excluded(pathname, options):
+  for glob in options.include:
+    if fnmatch.fnmatch(pathname, glob):
+      return False
+
+  for glob in options.exclude:
+    if fnmatch.fnmatch(pathname, glob):
+      return True
+
+  return False
 
 def walk_filesystem(source, options):
     if os.path.isdir(source):
         for dirpath, dirnames, filenames in os.walk(source):
+            if excluded(dirpath, options):
+                continue
             for filename in filenames:
                 abs_path = os.path.join(dirpath, filename)
                 if not os.path.isfile(abs_path):
+                    continue
+                if excluded(filename, options):
                     continue
                 rel_path = os.path.relpath(abs_path, source)
                 key_name = '/'.join([options.prefix] + rel_path.split(os.sep))
                 yield (key_name, dict(path=abs_path))
     elif os.path.isfile(source):
-        key_name = os.path.normpath(os.path.join(options.prefix, source))
-        yield (key_name, dict(path=source))
+        if not excluded(source, options):
+            key_name = os.path.normpath(os.path.join(options.prefix, source))
+            yield (key_name, dict(path=source))
 
 
 def walk_tar(source, options):
@@ -149,11 +165,12 @@ def walk_tar(source, options):
         for tarinfo in tar_file:
             if tarinfo.isfile():
                 path = tarinfo.name
-                key_name = os.path.normpath(os.path.join(options.prefix, path))
-                filename = source
-                offset = tarinfo.offset_data
-                size = tarinfo.size
-                yield (key_name, dict(filename=filename, offset=offset, path=path, size=size))
+                if not excluded(path, options):
+                    key_name = os.path.normpath(os.path.join(options.prefix, path))
+                    filename = source
+                    offset = tarinfo.offset_data
+                    size = tarinfo.size
+                    yield (key_name, dict(filename=filename, offset=offset, path=path, size=size))
             # http://blogs.oucs.ox.ac.uk/inapickle/2011/06/20/high-memory-usage-when-using-pythons-tarfile-module/
             tar_file.members = []
     except tarfile.ReadError:
@@ -161,21 +178,23 @@ def walk_tar(source, options):
         for tarinfo in tar_file:
             if tarinfo.isfile():
                 path = tarinfo.name
-                key_name = os.path.normpath(os.path.join(options.prefix, path))
-                content = tar_file.extractfile(tarinfo).read()
-                yield (key_name, dict(content=content, path=path))
+                if not excluded(path, options):
+                    key_name = os.path.normpath(os.path.join(options.prefix, path))
+                    content = tar_file.extractfile(tarinfo).read()
+                    yield (key_name, dict(content=content, path=path))
 
 
 def walk_s3(source, options):
     connection = S3Connection(host=options.host, is_secure=options.secure)
     for key in connection.get_bucket(source).list():
-        yield (
-            key.name,
-            dict(
-                bucket_name=key.bucket.name,
-                md5=key.etag,
-                size=key.size,
-                path='%s/%s' % (source, key.name)))
+        if not excluded(key.name, options):
+            yield (
+                key.name,
+                dict(
+                    bucket_name=key.bucket.name,
+                    md5=key.etag,
+                    size=key.size,
+                    path='%s/%s' % (source, key.name)))
 
 
 def walker(walk, put_queue, sources, options):
@@ -331,6 +350,10 @@ def main(argv):
     group = OptionGroup(parser, 'Source options')
     group.add_option('--walk', choices=('filesystem', 'tar', 's3'), default='filesystem', metavar='MODE',
             help='set walk mode (filesystem or tar)')
+    group.add_option('--exclude', action='append', default=[], metavar='PATTERN', 
+            help='exclude files matching PATTERN')
+    group.add_option('--include', action='append', default=[], metavar='PATTERN', 
+            help='don\'t exclude files matching PATTERN')
     parser.add_option_group(group)
     group = OptionGroup(parser, 'Put options')
     group.add_option('--content-type', default='guess', metavar='CONTENT-TYPE',


### PR DESCRIPTION
Pull request adds `--include` and `--exclude` arguments.

When `--walk` mode is `filesystem`, these arguments replicate rsyncs `--include` and `--exclude` flags; they work on each element of the source file path. This allows s3-parallel-sync to work as a replacement for rsync (our use case) with minimal changes.

When `--walk` mode is `tar` they match against the path returned by `tarinfo.name`.

When `--walk` mode is `s3` they match against `key.name`.

I've tested this change against the `filesystem` and `tar` walkers.