### PR TITLE
Basic mime-magic implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Dependencies
 
 * Python 2.X
 * [Boto](http://code.google.com/p/boto/)
+* [python-magic](https://github.com/ahupp/python-magic)
 
 
 Usage

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -38,7 +38,7 @@ from ssl import SSLError
 import sys
 import tarfile
 import time
-import magic
+import magic #python-magic
 import mimetypes
 
 import boto
@@ -265,10 +265,12 @@ def putter(put, put_queue, stat_queue, options):
 
                     content_type = None
                     if options.content_type:
-                        if options.content_type in ["guess", "magic"]:
+                        if options.content_type == 'guess':
                             content_type = mimetypes.guess_type(value.path)[0]
-                            if options.content_type == "magic" and content_type is None:
-                              content_type = magic.from_file(value.path, mime=True)
+                        if options.content_type == "magic":
+                            content_type = mimetypes.guess_type(value.path)[0]
+                            if content_type is None:
+                                content_type = magic.from_file(value.path, mime=True)
                         else:
                             content_type = options.content_type
                         headers['Content-Type'] = content_type

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -38,6 +38,7 @@ from ssl import SSLError
 import sys
 import tarfile
 import time
+import magic
 import mimetypes
 
 import boto
@@ -264,8 +265,10 @@ def putter(put, put_queue, stat_queue, options):
 
                     content_type = None
                     if options.content_type:
-                        if options.content_type == "guess":
+                        if options.content_type in ["guess", "magic"]:
                             content_type = mimetypes.guess_type(value.path)[0]
+                            if options.content_type == "magic" and content_type is None:
+                              content_type = magic.from_file(value.path, mime=True)
                         else:
                             content_type = options.content_type
                         headers['Content-Type'] = content_type
@@ -334,7 +337,8 @@ def main(argv):
     parser.add_option_group(group)
     group = OptionGroup(parser, 'Put options')
     group.add_option('--content-type', default='guess', metavar='CONTENT-TYPE',
-            help='set content type, set to "guess" to guess based on file name')
+            help='set content type, set to "guess" to guess based on file name '
+            'or "magic" to guess by filename and libmagic.')
     group.add_option('--gzip', action='store_true',
             help='gzip values and set content encoding')
     group.add_option('--gzip-type', action='append', default=[],


### PR DESCRIPTION
Adds `magic` as an option for `--content-type`.

`python-magic` uses libmagic to inspect the first few bytes of a file, determining content type using heuristics.

When magic is chosen, `mimetypes.guess_type` takes the first pass at determining the mime type based on filename extension. If mimetypes is unable to determine the mime type, magic is used as a fallback.

Using the extension is preferred over magic as magic is often unable to determine the difference between file types. E.g. `text/css` is often detected as `text/plain`. This replicates the behavior of many web-servers, making it somewhat easier to migrate sites into s3 for static hosting.

This does add a new dependency to python-magic. I initially considered making the import conditional on the user specifying `--content-type=magic`, however that didn't seem to be particularly pythonic.