### PR TITLE
Use boto for a s3 bucket named with dots

### DIFF
--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -422,6 +422,11 @@ def main(argv):
        is_secure=True,
        calling_format = boto.s3.connection.OrdinaryCallingFormat(),
        )
+    
+    import ssl
+    if hasattr(ssl, '_create_unverified_context'):
+         ssl._create_default_https_context = ssl._create_unverified_context
+            
     bucket = connection.get_bucket(options.bucket)
     del bucket
     del connection


### PR DESCRIPTION
Using boto for a s3 bucket named with dots, e.g. my.bucket.s3.amazonaws.com fails:

ssl.CertificateError: hostname 'my.bucket.s3.amazonaws.com' doesn't match either of '*.s3.amazonaws.com', 's3.amazonaws.com'