### PR TITLE
Handle BotoServerError

### DIFF
--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -46,6 +46,7 @@ import boto
 from boto.s3.connection import S3Connection
 from boto.s3.acl import CannedACLStrings
 from boto.utils import compute_md5
+from boto.exception import BotoServerError
 
 
 DONE_RE = re.compile(r'\AINFO:s3-parallel-put\[putter-\d+\]:\S+\s+->\s+(\S+)\s*\Z')

--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -324,6 +324,9 @@ def putter(put, put_queue, stat_queue, options):
             connection, bucket = None, None
         except IOError as exc:
             logger.error('%s -> %s (%s)' % (value.path, key_name, exc))
+        except BotoServerError as exc:
+            logger.error('%s -> %s (%s)' % (value.path, key_name, exc))
+            put_queue.put(args)
         put_queue.task_done()
 
 


### PR DESCRIPTION
503 slow down errors are not handled, which could result an incomplete upload without the user noticing. A quick fix would be catching BotoServerError and adding the errored item back to the queue.
