### PR TITLE
Add support for --content-encoding

### DIFF
--- a/s3-parallel-put
+++ b/s3-parallel-put
@@ -308,6 +308,9 @@ def putter(put, put_queue, stat_queue, options):
                         else:
                             content_type = options.content_type
                         headers['Content-Type'] = content_type
+                    
+                    if options.content_encoding:
+                        headers['Content-Encoding'] = options.content_encoding
 
                     content = value.get_content()
                     md5 = value.md5
@@ -384,6 +387,8 @@ def main(argv):
     group.add_option('--content-type', default='guess', metavar='CONTENT-TYPE',
             help='set content type, set to "guess" to guess based on file name '
             'or "magic" to guess by filename and libmagic.')
+    group.add_option('--content-encoding', default=None, metavar='CONTENT-ENCODING',
+            help='set content encoding.')    
     group.add_option('--gzip', action='store_true',
             help='gzip values and set content encoding')
     group.add_option('--gzip-type', action='append', default=[],


### PR DESCRIPTION
Allows a Content-Encoding header to be set. Useful if the files being uploaded are already gzipped.